### PR TITLE
Remove the need for adding trailing / to tile dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An image can be built out of circles, lines, waves, cross stitches, legos, minec
 
 - Make a folder with the tiles to build the image;
     - The script gen_tiles.py can help in this task; it builds tiles with multiple colors based on the source tile (note: its recommended for the source file to have an RGB color of (240,240,240));
-- Run `python tiler.py path/to/image path/to/tiles_folder/` (**note the trailing slash on the tiles folder**).
+- Run `python tiler.py path/to/image path/to/tiles_folder/`.
 
 ## Configuration
 

--- a/tiler.py
+++ b/tiler.py
@@ -80,7 +80,7 @@ def load_tiles(paths):
     for path in paths:
         if os.path.isdir(path):
             for tile_name in tqdm(os.listdir(path)):
-                tile = read_image(path + tile_name)
+                tile = read_image(os.path.join(path, tile_name))
                 mode, rel_freq = mode_color(tile)
                 if mode != None:
                     for scale in RESIZING_SCALES:


### PR DESCRIPTION
os.path.join() automatically takes care of this and adds the correct /
based on the OS it runs on.